### PR TITLE
pass empty values in CSV for unused fields in delete records

### DIFF
--- a/destination/format/csv.go
+++ b/destination/format/csv.go
@@ -361,6 +361,10 @@ func getColumnValue(
 		return fmt.Sprint(s.updatedAt.UnixMicro()), nil
 	case c == cnCols.DeletedAtColumn && r.Operation == sdk.OperationDelete:
 		return fmt.Sprint(s.deletedAt.UnixMicro()), nil
+	case r.Operation == sdk.OperationDelete && c != cnCols.DeletedAtColumn && c != cnCols.OperationColumn:
+		// for deletes, pass empty string for everything that isn't primary key, operation, or meroxa_deleted_at.
+		// those are the only fields we use for deletes.
+		return "", nil
 	case data[c] == nil:
 		return "", nil
 	case (!isOperationTimestampColumn(c, cnCols)) && isDateOrTimeType(schema[c]):

--- a/destination/format/csv_test.go
+++ b/destination/format/csv_test.go
@@ -180,7 +180,9 @@ func Test_MakeCSVBytes(t *testing.T) {
 
 				err = updateWriter.Write([]string{"update", "", fmt.Sprint(testTimestamp), "", "3", "squidward", "tentacles"})
 				require.NoError(t, err)
-				err = updateWriter.Write([]string{"delete", "", "", fmt.Sprint(testTimestamp), "4", "eugene", "krabs"})
+
+				// expect empty strings for everything but operation, meroxa_deleted_at, and primary key.
+				err = updateWriter.Write([]string{"delete", "", "", fmt.Sprint(testTimestamp), "4", "", ""})
 				require.NoError(t, err)
 				updateWriter.Flush()
 


### PR DESCRIPTION
### Description

For deletes, this ensures that we have empty values in CSV fields for everything except:
- primary key
- `<prefix>_deleted_at`
- `<prefix>_operation`

We will use the primary key in the MERGE query, and then only update the `_deleted_at` and `_operation` fields in the snowflake destination table.

Manual testing is in progress.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-snowflake/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
